### PR TITLE
`NetworkPolicies`

### DIFF
--- a/modules/gcp-cluster/README.md
+++ b/modules/gcp-cluster/README.md
@@ -40,6 +40,8 @@
 | [kubernetes_namespace.humanitec_agent](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.humanitec_operator](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.humanitec_runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_network_policy.humanitec_agent_deny_all](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.humanitec_agent_egress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_role.humanitec_deploy_runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
 | [kubernetes_role.humanitec_runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
 | [kubernetes_role_binding.humanitec_deploy_runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |

--- a/modules/gcp-cluster/README.md
+++ b/modules/gcp-cluster/README.md
@@ -42,6 +42,8 @@
 | [kubernetes_namespace.humanitec_runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_network_policy.humanitec_agent_deny_all](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.humanitec_agent_egress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.humanitec_runner_deny_all](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.humanitec_runner_egress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_role.humanitec_deploy_runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
 | [kubernetes_role.humanitec_runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
 | [kubernetes_role_binding.humanitec_deploy_runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |

--- a/modules/gcp-cluster/README.md
+++ b/modules/gcp-cluster/README.md
@@ -42,6 +42,8 @@
 | [kubernetes_namespace.humanitec_runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_network_policy.humanitec_agent_deny_all](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.humanitec_agent_egress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.humanitec_operator_deny_all](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.humanitec_operator_egress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.humanitec_runner_deny_all](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.humanitec_runner_egress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_role.humanitec_deploy_runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |

--- a/modules/gcp-cluster/humanitec_agent.tf
+++ b/modules/gcp-cluster/humanitec_agent.tf
@@ -52,3 +52,61 @@ resource "helm_release" "humanitec_agent" {
     }
   ]
 }
+
+resource "kubernetes_network_policy" "humanitec_agent_deny_all" {
+  metadata {
+    name      = "deny-all"
+    namespace = kubernetes_namespace.humanitec_agent.metadata[0].name
+  }
+
+  spec {
+    pod_selector {}
+
+    policy_types = ["Ingress", "Egress"]
+  }
+}
+
+resource "kubernetes_network_policy" "humanitec_agent_egress" {
+  metadata {
+    name      = "egress-from-humanitec-agent"
+    namespace = kubernetes_namespace.humanitec_agent.metadata[0].name
+  }
+
+  spec {
+    pod_selector {
+      match_labels = {
+        "app.kubernetes.io/name" = "humanitec-agent"
+      }
+    }
+
+    egress {
+      to {
+        ip_block {
+          cidr = "0.0.0.0/0"
+        }
+      }
+      ports {
+        port     = "443"
+        protocol = "TCP"
+      }
+    }
+
+    egress {
+      to {
+        ip_block {
+          cidr = "169.254.20.10/32"
+        }
+      }
+      ports {
+        port     = "53"
+        protocol = "TCP"
+      }
+      ports {
+        port     = "53"
+        protocol = "UDP"
+      }
+    }
+
+    policy_types = ["Egress"]
+  }
+}

--- a/modules/gcp-cluster/humanitec_agent.tf
+++ b/modules/gcp-cluster/humanitec_agent.tf
@@ -94,7 +94,7 @@ resource "kubernetes_network_policy" "humanitec_agent_egress" {
     egress {
       to {
         ip_block {
-          cidr = "169.254.20.10/32"
+          cidr = "169.254.20.10/32" /* NodeLocal DNSCache with Cloud DNS */
         }
       }
       ports {

--- a/modules/gcp-cluster/humanitec_operator.tf
+++ b/modules/gcp-cluster/humanitec_operator.tf
@@ -105,3 +105,86 @@ resource "kubernetes_manifest" "default_secretstore" {
   }
   depends_on = [helm_release.humanitec_operator]
 }
+
+resource "kubernetes_network_policy" "humanitec_operator_deny_all" {
+  metadata {
+    name      = "deny-all"
+    namespace = kubernetes_namespace.humanitec_operator.metadata[0].name
+  }
+
+  spec {
+    pod_selector {}
+
+    policy_types = ["Ingress", "Egress"]
+  }
+}
+
+resource "kubernetes_network_policy" "humanitec_operator_egress" {
+  metadata {
+    name      = "egress-from-humanitec-operator"
+    namespace = kubernetes_namespace.humanitec_operator.metadata[0].name
+  }
+
+  spec {
+    pod_selector {
+      match_labels = {
+        "app.kubernetes.io/name" = "humanitec-operator"
+      }
+    }
+
+    egress {
+      to {
+        ip_block {
+          cidr = "0.0.0.0/0"
+        }
+      }
+      ports {
+        port     = "443"
+        protocol = "TCP"
+      }
+    }
+
+    egress {
+      to {
+        ip_block {
+          cidr = "169.254.20.10/32" /* NodeLocal DNSCache with Cloud DNS */
+        }
+      }
+      ports {
+        port     = "53"
+        protocol = "TCP"
+      }
+      ports {
+        port     = "53"
+        protocol = "UDP"
+      }
+    }
+
+    egress {
+      to {
+        ip_block {
+          cidr = "169.254.169.254/32" /* GKE Workload Identity */
+        }
+      }
+      ports {
+        port     = "80"
+        protocol = "TCP"
+      }
+    }
+    
+    egress {
+      to {
+        ip_block {
+          cidr = "169.254.169.252/32" /* GKE Workload Identity */
+        }
+      }
+      ports {
+        port     = "988"
+        protocol = "TCP"
+      }
+    }
+
+
+    policy_types = ["Egress"]
+  }
+}

--- a/modules/gcp-cluster/humanitec_operator.tf
+++ b/modules/gcp-cluster/humanitec_operator.tf
@@ -171,7 +171,7 @@ resource "kubernetes_network_policy" "humanitec_operator_egress" {
         protocol = "TCP"
       }
     }
-    
+
     egress {
       to {
         ip_block {

--- a/modules/gcp-cluster/humanitec_runner.tf
+++ b/modules/gcp-cluster/humanitec_runner.tf
@@ -101,3 +101,61 @@ resource "kubernetes_role_binding" "humanitec_deploy_runner" {
     name      = google_service_account.gke_cluster_access.email
   }
 }
+
+resource "kubernetes_network_policy" "humanitec_runner_deny_all" {
+  metadata {
+    name      = "deny-all"
+    namespace = kubernetes_namespace.humanitec_runner.metadata[0].name
+  }
+
+  spec {
+    pod_selector {}
+
+    policy_types = ["Ingress", "Egress"]
+  }
+}
+
+resource "kubernetes_network_policy" "humanitec_runner_egress" {
+  metadata {
+    name      = "egress-from-humanitec-runner"
+    namespace = kubernetes_namespace.humanitec_runner.metadata[0].name
+  }
+
+  spec {
+    pod_selector {
+      /*match_labels = {
+        "app.kubernetes.io/name" = "humanitec-runner"
+      }*/
+    }
+
+    egress {
+      to {
+        ip_block {
+          cidr = "0.0.0.0/0"
+        }
+      }
+      ports {
+        port     = "443"
+        protocol = "TCP"
+      }
+    }
+
+    egress {
+      to {
+        ip_block {
+          cidr = "169.254.20.10/32"
+        }
+      }
+      ports {
+        port     = "53"
+        protocol = "TCP"
+      }
+      ports {
+        port     = "53"
+        protocol = "UDP"
+      }
+    }
+
+    policy_types = ["Egress"]
+  }
+}

--- a/modules/gcp-cluster/humanitec_runner.tf
+++ b/modules/gcp-cluster/humanitec_runner.tf
@@ -143,7 +143,7 @@ resource "kubernetes_network_policy" "humanitec_runner_egress" {
     egress {
       to {
         ip_block {
-          cidr = "169.254.20.10/32"
+          cidr = "169.254.20.10/32" /* NodeLocal DNSCache with Cloud DNS */
         }
       }
       ports {

--- a/modules/htc-org/manifests/base-env/definition-values.yaml
+++ b/modules/htc-org/manifests/base-env/definition-values.yaml
@@ -11,7 +11,19 @@ templates:
           gcpsm:
             auth: {}
             projectID: ${resources['config#app'].outputs.gcp_project_id}
-    network-policy.yaml:
+    network-policy-denyall.yaml:
+      location: namespace
+      data:
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: deny-all
+        spec:
+          podSelector: {}
+          policyTypes:
+            - Ingress
+            - Egress
+    network-policy-default.yaml:
       location: namespace
       data:
         apiVersion: networking.k8s.io/v1
@@ -19,7 +31,9 @@ templates:
         metadata:
           name: default
         spec:
-          podSelector: {}
+          podSelector:
+            matchLabels:
+              humanitec.io/trusted-workload: "true"
           policyTypes:
             - Ingress
             - Egress

--- a/modules/htc-org/manifests/base-env/definition-values.yaml
+++ b/modules/htc-org/manifests/base-env/definition-values.yaml
@@ -39,10 +39,14 @@ templates:
             - Egress
           ingress:
             - from:
-              - podSelector: {}
+              - podSelector:
+                  matchLabels:
+                    humanitec.io/trusted-workload: "true"
           egress:
             - to:
-              - podSelector: {}
+              - podSelector:
+                  matchLabels:
+                    humanitec.io/trusted-workload: "true"
             - to:
               - ipBlock:
                   cidr: 0.0.0.0/0

--- a/modules/htc-org/manifests/postgres/definition-values.yaml
+++ b/modules/htc-org/manifests/postgres/definition-values.yaml
@@ -37,11 +37,11 @@ templates:
           serviceName: postgres
           selector:
             matchLabels:
-              app: {{ .init.name }}
+              app.kubernetes.io/name: {{ .init.name }}
           template:
             metadata:
               labels:
-                app: {{ .init.name }}
+                app.kubernetes.io/name: {{ .init.name }}
             spec:
               automountServiceAccountToken: false
               containers:
@@ -100,7 +100,7 @@ templates:
           ports:
           - port: {{ .init.port }}
           selector:
-            app: {{ .init.name }}
+            app.kubernetes.io/name: {{ .init.name }}
           clusterIP: None
     secret.yaml:
       location: namespace
@@ -112,6 +112,30 @@ templates:
         type: Opaque
         data:
           POSTGRES_PASSWORD: {{ .init.password | b64enc }}
+    networkpolicy.yaml:
+      location: namespace
+      data:
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: ingress-to-{{ .init.name }}
+        spec:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ .init.name }}
+          policyTypes:
+            - Ingress
+          ingress:
+            - from:
+              - podSelector:
+                  matchLabels:
+                    {{- if regexMatch "modules\\.[a-z0-9-]+\\.externals" .driver.values.resId }}
+                    app.kubernetes.io/name: {{ index (splitList "." .driver.values.resId) 1 }}
+                    {{- else }}
+                    humanitec.io/trusted-workload: "true"
+                    {{- end }}
+              ports:
+                - port: {{ .init.port }}
   outputs: |-
     host: {{ .init.name }}
     port: {{ .init.port }}

--- a/modules/htc-org/manifests/postgres/definition-values.yaml
+++ b/modules/htc-org/manifests/postgres/definition-values.yaml
@@ -42,6 +42,7 @@ templates:
             metadata:
               labels:
                 app.kubernetes.io/name: {{ .init.name }}
+                humanitec.io/trusted-workload: "true"
             spec:
               automountServiceAccountToken: false
               containers:
@@ -123,6 +124,7 @@ templates:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: {{ .init.name }}
+              humanitec.io/trusted-workload: "true"
           policyTypes:
             - Ingress
           ingress:
@@ -131,9 +133,8 @@ templates:
                   matchLabels:
                     {{- if regexMatch "modules\\.[a-z0-9-]+\\.externals" .driver.values.resId }}
                     app.kubernetes.io/name: {{ index (splitList "." .driver.values.resId) 1 }}
-                    {{- else }}
-                    humanitec.io/trusted-workload: "true"
                     {{- end }}
+                    humanitec.io/trusted-workload: "true"
               ports:
                 - port: {{ .init.port }}
   outputs: |-

--- a/modules/htc-org/manifests/redis/definition-values.yaml
+++ b/modules/htc-org/manifests/redis/definition-values.yaml
@@ -32,6 +32,7 @@ templates:
             metadata:
               labels:
                 app.kubernetes.io/name: {{ .init.name }}
+                humanitec.io/trusted-workload: "true"
             spec:
               automountServiceAccountToken: false
               securityContext:
@@ -93,6 +94,7 @@ templates:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: {{ .init.name }}
+              humanitec.io/trusted-workload: "true"
           policyTypes:
             - Ingress
           ingress:
@@ -101,9 +103,8 @@ templates:
                   matchLabels:
                     {{- if regexMatch "modules\\.[a-z0-9-]+\\.externals" .driver.values.resId }}
                     app.kubernetes.io/name: {{ index (splitList "." .driver.values.resId) 1 }}
-                    {{- else }}
-                    humanitec.io/trusted-workload: "true"
                     {{- end }}
+                    humanitec.io/trusted-workload: "true"
               ports:
                 - port: {{ .init.port }}
   outputs: |-

--- a/modules/htc-org/manifests/redis/definition-values.yaml
+++ b/modules/htc-org/manifests/redis/definition-values.yaml
@@ -60,7 +60,7 @@ templates:
                     memory: 64Mi
                 ports:
                 - name: tcp-redis
-                  containerPort: 6379
+                  containerPort: {{ .init.port }}
                 volumeMounts:
                 - mountPath: /data
                   name: redis-data
@@ -88,7 +88,7 @@ templates:
         apiVersion: networking.k8s.io/v1
         kind: NetworkPolicy
         metadata:
-          name: redis-ingress
+          name: ingress-to-{{ .init.name }}
         spec:
           podSelector:
             matchLabels:
@@ -104,10 +104,11 @@ templates:
                     {{- else }}
                     humanitec.io/trusted-workload: "true"
                     {{- end }}
+              ports:
+                - port: {{ .init.port }}
   outputs: |-
     host: {{ .init.name }}
     port: {{ .init.port }}
-    test: {{ regexMatch "modules\\.[a-z0-9-]+\\.externals" .driver.values.resId }}
   secrets: |-
     username: ""
     password: ""

--- a/modules/htc-org/manifests/redis/definition-values.yaml
+++ b/modules/htc-org/manifests/redis/definition-values.yaml
@@ -10,7 +10,7 @@ templates:
     {{- else }}
     port: 6379
     # Deployment names shouldn't be > 47 https://pauldally.medium.com/why-you-try-to-keep-your-deployment-names-to-47-characters-or-less-1f93a848d34c
-    {{ if regexMatch "modules\\.[a-z0-9-]+\\.externals" .driver.values.resId }}
+    {{- if regexMatch "modules\\.[a-z0-9-]+\\.externals" .driver.values.resId }}
     name: redis-{{ index (splitList "." .driver.values.resId) 1 | substr 0 20 }}-{{ index (splitList "." .driver.values.resId) 3 | substr 0 20 }}
     {{- else }}
     name: redis-{{ index (splitList "." .driver.values.resId) 1 | substr 0 40 }}
@@ -27,11 +27,11 @@ templates:
         spec:
           selector:
             matchLabels:
-              app: {{ .init.name }}
+              app.kubernetes.io/name: {{ .init.name }}
           template:
             metadata:
               labels:
-                app: {{ .init.name }}
+                app.kubernetes.io/name: {{ .init.name }}
             spec:
               automountServiceAccountToken: false
               securityContext:
@@ -77,14 +77,37 @@ templates:
         spec:
           type: ClusterIP
           selector:
-            app: {{ .init.name }}
+            app.kubernetes.io/name: {{ .init.name }}
           ports:
           - name: tcp-redis
             port: {{ .init.port }}
             targetPort: tcp-redis
+    networkpolicy.yaml:
+      location: namespace
+      data:
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: redis-ingress
+        spec:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ .init.name }}
+          policyTypes:
+            - Ingress
+          ingress:
+            - from:
+              - podSelector:
+                  matchLabels:
+                    {{- if regexMatch "modules\\.[a-z0-9-]+\\.externals" .driver.values.resId }}
+                    app.kubernetes.io/name: {{ index (splitList "." .driver.values.resId) 1 }}
+                    {{- else }}
+                    humanitec.io/trusted-workload: "true"
+                    {{- end }}
   outputs: |-
     host: {{ .init.name }}
     port: {{ .init.port }}
+    test: {{ regexMatch "modules\\.[a-z0-9-]+\\.externals" .driver.values.resId }}
   secrets: |-
     username: ""
     password: ""

--- a/modules/htc-org/manifests/workload/definition-values.yaml
+++ b/modules/htc-org/manifests/workload/definition-values.yaml
@@ -2,6 +2,13 @@ templates:
   outputs: |-
     update:
       - op: add
+        path: /spec/pod/labels
+        value:
+          {{- range $key, $val := .resource.spec.pod.labels }}
+          {{ $key }}: {{ $val | quote }}
+          {{- end }}
+          humanitec.io/trusted-workload: "true"
+      - op: add
         path: /spec/serviceAccountName
         value: ${resources.k8s-service-account.outputs.name}
       - op: add


### PR DESCRIPTION
Continuity of https://github.com/mathieu-benoit/humanitec-ref-arch/commit/41c5f5836965c36439949d6cf2dfcf03be54d2ab, with in addition:
- [x] More granular policies with Workload (new `humanitec.io/trusted-workload: "true"` label)
- [x] Add policy for the in-cluster `redis` (shared or not)
- [x] Add policy for the in-cluster `postgres` (shared or not)
- [x] Add policies for Humanitec Operator
- [x] Add policies for Humanitec Agent
- [x] Add policies for Humanitec TF runner

Example with the OnlineBoutique sample apps, `kubectl get netpol`:
```none
NAMESPACE                     NAME                                   POD-SELECTOR
humanitec-agent               deny-all                               <none>
humanitec-agent               egress-from-humanitec-agent            app.kubernetes.io/name=humanitec-agent
humanitec-operator-system     deny-all                               <none>
humanitec-operator-system     egress-from-humanitec-operator         app.kubernetes.io/name=humanitec-operator
humanitec-runner              deny-all                               <none>
humanitec-runner              egress-from-humanitec-runner           <none>
online-boutique-development   default                                humanitec.io/trusted-workload=true
online-boutique-development   deny-all                               <none>
online-boutique-development   ingress-to-frontend                    app.kubernetes.io/name=frontend
online-boutique-development   ingress-to-redis-cart-redis-cart       app.kubernetes.io/name=redis-cart-redis-cart,humanitec.io/trusted-workload=true
```

`ingress-to-redis`:
<img width="917" height="344" alt="image" src="https://github.com/user-attachments/assets/4ea78381-c0b7-45ab-a343-885b0262bcbd" />

`default`:
<img width="926" height="400" alt="image" src="https://github.com/user-attachments/assets/cbbbe440-a792-4299-b97b-b98b8a630722" />

`ingress-to-workload`:
<img width="929" height="337" alt="image" src="https://github.com/user-attachments/assets/3abae8da-fe10-4f76-b726-e68d81901e7e" />

`humanitec-agent`:
<img width="914" height="388" alt="image" src="https://github.com/user-attachments/assets/f60449e6-ad10-4801-ac95-26d1ca320c40" />

`humanitec-operator`:
<img width="912" height="432" alt="image" src="https://github.com/user-attachments/assets/b3a36ed7-a675-4524-8515-759790e8fe16" />
